### PR TITLE
Fix engine repair effect timing

### DIFF
--- a/client/modules/maintenance.lua
+++ b/client/modules/maintenance.lua
@@ -51,12 +51,16 @@ if not DoesEntityExist(vehicle) then return end
             clip = Config.Animations.repair.anim
         }
     })
-    
+
+    if effects and effects.stop then
+        effects.stop()
+    end
+
     if progress then
         -- Simulated effect of maintenance
         local health = GetVehicleEngineHealth(vehicle) + maintenanceItem.restores
         SetVehicleEngineHealth(vehicle, math.min(health, 1000.0))
-        
+
         exports.ox_inventory:RemoveItem(maintenanceItem.item, 1)
         
         lib.notify({


### PR DESCRIPTION
## Summary
- replace the engine repair spark loop to use supported timers and guard cleanup
- ensure particle handles and animation are cleared when the repair stops
- stop the repair visual effect after the maintenance progress bar completes

## Testing
- not run (requires in-game verification)

------
https://chatgpt.com/codex/tasks/task_e_68f127f8ffa0832cb6bdf4e699ef8ee2