### PR TITLE
Fix resource name reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A comprehensive mechanic job system for FiveM with ox_lib integration.
 ## Installation
 
 1. Download and extract the resource to your resources folder
-2. Add `ensure advanced-mechanic` to your server.cfg
+2. Add `ensure advance-mechanic` to your server.cfg
 3. Import the SQL file to your database
 4. Import `fluid_data_migration.sql` to add fluid data columns
 5. Configure the resource in `config.lua`


### PR DESCRIPTION
## Summary
- update the installation instructions to reference the correct `ensure advance-mechanic` resource name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f26d38d970832c96ec2fd719cb018c