### PR TITLE
Improve mission lifecycle handling

### DIFF
--- a/server/modules/missions.lua
+++ b/server/modules/missions.lua
@@ -1,6 +1,18 @@
 local Missions = {}
 
 local activeMissions = {}
+local missionCounter = 0
+
+local function removeMissionForPlayer(playerId)
+    if not playerId then return end
+
+    local mission = activeMissions[playerId]
+    if mission then
+        activeMissions[playerId] = nil
+    end
+
+    return mission
+end
 
 -- Generate a new mission
 function Missions.Generate(source)
@@ -11,14 +23,19 @@ function Missions.Generate(source)
     local location = locations[math.random(#locations)]
     local vehicleModel = Config.NPCMissions.vehicles[math.random(#Config.NPCMissions.vehicles)]
     
+    missionCounter = missionCounter + 1
+
     local mission = {
         coords = vector3(location.coords.x, location.coords.y, location.coords.z),
         model = vehicleModel,
         payout = math.random(Config.NPCMissions.payouts.repair.min, Config.NPCMissions.payouts.repair.max),
-        description = locale('repair_mission_description', vehicleModel)
+        description = locale('repair_mission_description', vehicleModel),
+        id = ('mission_%d'):format(missionCounter),
+        player = source,
+        startedAt = os.time()
     }
-    
-    table.insert(activeMissions, mission)
+
+    activeMissions[source] = mission
     TriggerClientEvent('mechanic:client:newMission', source, mission)
     return mission
 end
@@ -28,30 +45,37 @@ function Missions.Complete(source, success)
     local Player = QBCore.Functions.GetPlayer(source)
     if not Player or Player.PlayerData.job.name ~= Config.JobName then return false end
     
-    for index, mission in ipairs(activeMissions) do
-        if mission.player == source then
-            table.remove(activeMissions, index)
-            if success then
-                Player.Functions.AddMoney('bank', mission.payout)
-                TriggerClientEvent('ox_lib:notify', source, {
-                    title = locale('mission_complete'),
-                    description = locale('earned_money', mission.payout),
-                    type = 'success'
-                })
-            else
-                TriggerClientEvent('ox_lib:notify', source, {
-                    title = locale('mission_failed'),
-                    type = 'error'
-                })
-            end
-            break
-        end
+    local mission = removeMissionForPlayer(source)
+    if not mission then return false end
+
+    if success then
+        Player.Functions.AddMoney('bank', mission.payout)
+        TriggerClientEvent('ox_lib:notify', source, {
+            title = locale('mission_complete'),
+            description = locale('earned_money', mission.payout),
+            type = 'success'
+        })
+    else
+        TriggerClientEvent('ox_lib:notify', source, {
+            title = locale('mission_failed'),
+            type = 'error'
+        })
     end
+
+    return true
 end
 
 -- Events
 RegisterNetEvent('mechanic:server:completeMission', function(success)
     Missions.Complete(source, success)
+end)
+
+AddEventHandler('playerDropped', function()
+    removeMissionForPlayer(source)
+end)
+
+RegisterNetEvent('QBCore:Server:OnPlayerUnload', function(playerId)
+    removeMissionForPlayer(playerId or source)
 end)
 
 -- Callbacks


### PR DESCRIPTION
## Summary
- associate generated missions with their creating player and unique identifiers
- switch active mission storage to player keyed lookups and add lifecycle metadata
- clean up missions automatically when a player disconnects or unloads

## Testing
- Not Run (lua interpreter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f26d32bb74832ca144d4173bab49a7