### PR TITLE
Ensure lift state handler handles missing active lift

### DIFF
--- a/client/modules/lifts.lua
+++ b/client/modules/lifts.lua
@@ -246,7 +246,7 @@ AddStateBagChangeHandler('liftMoving', nil, function(bagName, key, value, reserv
     if not entity or entity == 0 then return end
     
     local vehicleState = Entity(entity).state
-    if vehicleState.shopId == activeLift?.shopId and vehicleState.liftId == activeLift?.id then
+    if activeLift and vehicleState.shopId == activeLift.shopId and vehicleState.liftId == activeLift.id then
         -- Another player is controlling this lift
         lib.notify({
             title = locale('lift_in_use'),


### PR DESCRIPTION
## Summary
- gate the lift state bag warning behind an active lift check to avoid nil accesses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f64a001240832cab2d9f5b5a45cbe7