### PR TITLE
Fix fluid degradation and sync timers

### DIFF
--- a/client/modules/fluid_effects.lua
+++ b/client/modules/fluid_effects.lua
@@ -54,16 +54,15 @@ function FluidEffects.Start()
                 
                 -- Degradación automática cada 30 segundos y por kilometraje
                 if currentTime - lastDegradation >= 30000 or math.abs(mileage - lastMileage) >= 1 then
-                if currentTime - lastSync >= 300000 then
- 1 then
                     FluidEffects.DegradeFluidLevels(vehicle)
                     FluidEffects.DegradeComponents(vehicle)
                     lastDegradation = currentTime
                     lastMileage = mileage
                 end
-                
+
                 -- Sincronización con servidor cada 5 minutos
-                if currentTime - lastSync  300000 then
+                if currentTime - lastSync >= 300000 then
+ 300000 then
                     FluidEffects.SyncWithServer(vehicle)
                     lastSync = currentTime
                 end


### PR DESCRIPTION
## Summary
- ensure the fluid degradation guard only wraps the degradation logic
- run the periodic server synchronization every five minutes from its own timer block

## Testing
- ⚠️ `luac -p client/modules/fluid_effects.lua` *(fails: `luac` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f64e072ffc832cab871353ca81b417