### PR TITLE
Refactor fluid effects into modular components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+### Changed
+- Split the fluid simulation into dedicated modules for effects, degradation, and state management to improve readability and ox_lib-driven performance. 
+- Updated the fluid effects controller to use cache-driven start/stop logic and reduce idle processing while the player is not driving.

--- a/client/modules/fluid/degradation.lua
+++ b/client/modules/fluid/degradation.lua
@@ -1,0 +1,98 @@
+local Degradation = {}
+
+function Degradation.applyComponentWear(vehicle)
+    local state = Entity(vehicle).state
+    local speed = GetEntitySpeed(vehicle) * 3.6
+    local engineHealth = GetVehicleEngineHealth(vehicle)
+    local bodyHealth = GetVehicleBodyHealth(vehicle)
+
+    local tireWearRate = 0.01
+    if speed > 80 then
+        tireWearRate = tireWearRate * 2
+    end
+    if speed > 150 then
+        tireWearRate = tireWearRate * 3
+    end
+
+    local surfaceHash = GetVehicleWheelSurfaceMaterial(vehicle, 0)
+    if surfaceHash == GetHashKey('SAND') or surfaceHash == GetHashKey('ROCK') then
+        tireWearRate = tireWearRate * 1.5
+    end
+
+    local currentTireWear = state.tireWear or 0
+    state:set('tireWear', math.min(100, currentTireWear + tireWearRate), true)
+
+    local batteryDrainRate = 0.02
+    if engineHealth < 800 then
+        batteryDrainRate = batteryDrainRate * 2
+    end
+    if speed == 0 and GetIsVehicleEngineRunning(vehicle) then
+        batteryDrainRate = batteryDrainRate * 1.5
+    end
+
+    local currentBattery = state.batteryLevel or 100
+    state:set('batteryLevel', math.max(0, currentBattery - batteryDrainRate), true)
+
+    local gearBoxDamageRate = 0.01
+    if speed > 120 then
+        gearBoxDamageRate = gearBoxDamageRate * 2
+    end
+    if bodyHealth < 800 then
+        gearBoxDamageRate = gearBoxDamageRate * 1.5
+    end
+
+    local currentGearBox = state.gearBoxHealth or 100
+    state:set('gearBoxHealth', math.max(0, currentGearBox - gearBoxDamageRate), true)
+end
+
+function Degradation.applyFluidLoss(vehicle)
+    local state = Entity(vehicle).state
+    local engineHealth = GetVehicleEngineHealth(vehicle)
+    local speed = GetEntitySpeed(vehicle) * 3.6
+
+    local oilDegradation = 0.1
+    local coolantDegradation = 0.1
+    local brakeDegradation = 0.05
+    local steeringDegradation = 0.05
+
+    if engineHealth < 900 then
+        oilDegradation = oilDegradation * 2
+        coolantDegradation = coolantDegradation * 1.5
+    end
+
+    if speed > 120 then
+        oilDegradation = oilDegradation * 1.5
+        coolantDegradation = coolantDegradation * 2
+        brakeDegradation = brakeDegradation * 2
+    end
+
+    local currentOil = state.oilLevel or 100
+    local currentCoolant = state.coolantLevel or 100
+    local currentBrake = state.brakeFluidLevel or 100
+    local currentSteering = state.powerSteeringLevel or 100
+
+    state:set('oilLevel', math.max(0, currentOil - oilDegradation), true)
+    state:set('coolantLevel', math.max(0, currentCoolant - coolantDegradation), true)
+    state:set('brakeFluidLevel', math.max(0, currentBrake - brakeDegradation), true)
+    state:set('powerSteeringLevel', math.max(0, currentSteering - steeringDegradation), true)
+end
+
+function Degradation.onCollision(vehicle, damage)
+    local state = Entity(vehicle).state
+
+    local batteryDamage = damage * 0.1
+    local currentBattery = state.batteryLevel or 100
+    state:set('batteryLevel', math.max(0, currentBattery - batteryDamage), true)
+
+    local gearBoxDamage = damage * 0.15
+    local currentGearBox = state.gearBoxHealth or 100
+    state:set('gearBoxHealth', math.max(0, currentGearBox - gearBoxDamage), true)
+
+    if damage > 50 then
+        local tireDamage = damage * 0.2
+        local currentTireWear = state.tireWear or 0
+        state:set('tireWear', math.min(100, currentTireWear + tireDamage), true)
+    end
+end
+
+return Degradation

--- a/client/modules/fluid/effects.lua
+++ b/client/modules/fluid/effects.lua
@@ -1,0 +1,314 @@
+local Effects = {}
+
+local function ensureHandlingCache(vehicle, cache, key, getter)
+    local entry = cache[vehicle]
+
+    if not entry then
+        entry = {}
+        cache[vehicle] = entry
+    end
+
+    if entry[key] == nil then
+        entry[key] = getter(vehicle)
+    end
+
+    return entry
+end
+
+function Effects.applyBrake(vehicle, fluidLevel, handlingCache)
+    local handling = ensureHandlingCache(vehicle, handlingCache, 'brakeForce', function(veh)
+        return GetVehicleHandlingFloat(veh, 'CHandlingData', 'fBrakeForce')
+    end)
+
+    local state = Entity(vehicle).state
+
+    if fluidLevel < 30 then
+        local reducedBrakeForce = handling.brakeForce * 0.3
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', reducedBrakeForce)
+
+        if not state.lowBrakeWarning then
+            state:set('lowBrakeWarning', true, true)
+            lib.notify({
+                title = locale('low_brake_fluid'),
+                description = locale('brakes_severely_reduced'),
+                type = 'error',
+                duration = 8000
+            })
+        end
+    elseif fluidLevel < 50 then
+        local reducedBrakeForce = handling.brakeForce * 0.6
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', reducedBrakeForce)
+
+        if not state.lowBrakeWarning then
+            state:set('lowBrakeWarning', true, true)
+            lib.notify({
+                title = locale('low_brake_fluid'),
+                description = locale('brakes_reduced'),
+                type = 'warning',
+                duration = 6000
+            })
+        end
+    else
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', handling.brakeForce)
+        state:set('lowBrakeWarning', false, true)
+    end
+end
+
+function Effects.applyEngine(vehicle, oilLevel, coolantLevel)
+    local state = Entity(vehicle).state
+    local engineTemp = state.engineTemp or 90
+
+    if oilLevel < 30 then
+        local currentHealth = GetVehicleEngineHealth(vehicle)
+        SetVehicleEngineHealth(vehicle, currentHealth - 0.5)
+
+        ModifyVehicleTopSpeed(vehicle, 0.7)
+
+        if not state.lowOilWarning then
+            state:set('lowOilWarning', true, true)
+            lib.notify({
+                title = locale('low_engine_oil'),
+                description = locale('engine_damage_risk'),
+                type = 'error',
+                duration = 8000
+            })
+        end
+    else
+        ModifyVehicleTopSpeed(vehicle, 1.0)
+        state:set('lowOilWarning', false, true)
+    end
+
+    if coolantLevel < 30 then
+        engineTemp = math.min(engineTemp + 2.0, 150)
+        state:set('engineTemp', engineTemp, true)
+
+        if engineTemp > 120 then
+            SetVehicleEngineOn(vehicle, false, true, false)
+
+            lib.notify({
+                title = locale('engine_overheated'),
+                description = locale('engine_shutdown'),
+                type = 'error',
+                duration = 10000
+            })
+
+            SetVehicleEngineHealth(vehicle, -100.0)
+        elseif not state.lowCoolantWarning then
+            state:set('lowCoolantWarning', true, true)
+            lib.notify({
+                title = locale('low_coolant'),
+                description = locale('engine_overheating'),
+                type = 'warning',
+                duration = 8000
+            })
+        end
+    else
+        if engineTemp > 90 then
+            engineTemp = math.max(engineTemp - 0.5, 90)
+            state:set('engineTemp', engineTemp, true)
+        end
+        state:set('lowCoolantWarning', false, true)
+    end
+end
+
+function Effects.applySteering(vehicle, fluidLevel, handlingCache)
+    local handling = ensureHandlingCache(vehicle, handlingCache, 'steeringLock', function(veh)
+        return GetVehicleHandlingFloat(veh, 'CHandlingData', 'fSteeringLock')
+    end)
+
+    local state = Entity(vehicle).state
+
+    if fluidLevel < 30 then
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', 25.0)
+
+        if not state.lowSteeringWarning then
+            state:set('lowSteeringWarning', true, true)
+            lib.notify({
+                title = locale('low_power_steering'),
+                description = locale('steering_difficulty'),
+                type = 'warning',
+                duration = 6000
+            })
+        end
+    elseif fluidLevel < 50 then
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', 35.0)
+
+        if not state.lowSteeringWarning then
+            state:set('lowSteeringWarning', true, true)
+            lib.notify({
+                title = locale('low_power_steering'),
+                description = locale('steering_slightly_heavy'),
+                type = 'info',
+                duration = 5000
+            })
+        end
+    else
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', handling.steeringLock)
+        state:set('lowSteeringWarning', false, true)
+    end
+end
+
+function Effects.applyTireWear(vehicle, tireWear, handlingCache)
+    local handling = ensureHandlingCache(vehicle, handlingCache, 'traction', function(veh)
+        return {
+            max = GetVehicleHandlingFloat(veh, 'CHandlingData', 'fTractionCurveMax'),
+            min = GetVehicleHandlingFloat(veh, 'CHandlingData', 'fTractionCurveMin')
+        }
+    end)
+
+    local state = Entity(vehicle).state
+
+    if tireWear > 80 then
+        if math.random(1, 1000) <= 5 then
+            local tireIndex = math.random(0, 3)
+            SetVehicleTyreBurst(vehicle, tireIndex, false, 1000.0)
+
+            lib.notify({
+                title = locale('tire_blowout'),
+                description = locale('tire_worn_out'),
+                type = 'error',
+                duration = 8000
+            })
+        end
+
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', handling.traction.max * 0.7)
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', handling.traction.min * 0.5)
+
+        if not state.tireWearWarning then
+            state:set('tireWearWarning', true, true)
+            lib.notify({
+                title = locale('tire_wear_critical'),
+                description = locale('replace_tires_soon'),
+                type = 'error',
+                duration = 10000
+            })
+        end
+    elseif tireWear > 60 then
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', handling.traction.max * 0.85)
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', handling.traction.min * 0.75)
+
+        if not state.tireWearWarning then
+            state:set('tireWearWarning', true, true)
+            lib.notify({
+                title = locale('tire_wear_high'),
+                description = locale('consider_tire_replacement'),
+                type = 'warning',
+                duration = 8000
+            })
+        end
+    else
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', handling.traction.max)
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', handling.traction.min)
+        state:set('tireWearWarning', false, true)
+    end
+end
+
+function Effects.applyBattery(vehicle, batteryLevel)
+    local state = Entity(vehicle).state
+
+    if batteryLevel < 20 then
+        if math.random(1, 100) <= 10 then
+            SetVehicleEngineOn(vehicle, false, true, false)
+
+            lib.notify({
+                title = locale('battery_dead'),
+                description = locale('vehicle_wont_start'),
+                type = 'error',
+                duration = 10000
+            })
+        end
+
+        SetVehicleLightMultiplier(vehicle, 0.3)
+
+        if not state.batteryWarning then
+            state:set('batteryWarning', true, true)
+            lib.notify({
+                title = locale('battery_critical'),
+                description = locale('charge_battery_soon'),
+                type = 'error',
+                duration = 8000
+            })
+        end
+    elseif batteryLevel < 40 then
+        SetVehicleLightMultiplier(vehicle, 0.7)
+
+        if not state.batteryWarning then
+            state:set('batteryWarning', true, true)
+            lib.notify({
+                title = locale('battery_low'),
+                description = locale('battery_needs_attention'),
+                type = 'warning',
+                duration = 6000
+            })
+        end
+    else
+        SetVehicleLightMultiplier(vehicle, 1.0)
+        state:set('batteryWarning', false, true)
+    end
+end
+
+function Effects.applyGearbox(vehicle, gearBoxHealth)
+    local state = Entity(vehicle).state
+
+    if gearBoxHealth < 30 then
+        if math.random(1, 100) <= 5 then
+            local randomGear = math.random(-1, 6)
+            SetVehicleGear(vehicle, randomGear)
+
+            lib.notify({
+                title = locale('gearbox_failure'),
+                description = locale('gears_changing_randomly'),
+                type = 'error',
+                duration = 8000
+            })
+        end
+
+        if not state.gearBoxWarning then
+            state:set('gearBoxWarning', true, true)
+            lib.notify({
+                title = locale('gearbox_critical'),
+                description = locale('transmission_failing'),
+                type = 'error',
+                duration = 10000
+            })
+        end
+    elseif gearBoxHealth < 60 then
+        if math.random(1, 200) <= 1 then
+            SetVehicleGear(vehicle, GetVehicleCurrentGear(vehicle))
+        end
+
+        if not state.gearBoxWarning then
+            state:set('gearBoxWarning', true, true)
+            lib.notify({
+                title = locale('gearbox_worn'),
+                description = locale('gear_changes_slow'),
+                type = 'warning',
+                duration = 6000
+            })
+        end
+    else
+        state:set('gearBoxWarning', false, true)
+    end
+end
+
+function Effects.restoreHandling(vehicle, handlingCache)
+    local handling = handlingCache[vehicle]
+    if not handling then return end
+
+    if handling.brakeForce then
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', handling.brakeForce)
+    end
+
+    if handling.steeringLock then
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', handling.steeringLock)
+    end
+
+    if handling.traction then
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', handling.traction.max)
+        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', handling.traction.min)
+    end
+
+    handlingCache[vehicle] = nil
+end
+
+return Effects

--- a/client/modules/fluid/state.lua
+++ b/client/modules/fluid/state.lua
@@ -1,0 +1,58 @@
+local State = {}
+
+function State.fetchInitialData(plate)
+    if not plate or plate == '' then return nil end
+    return lib.callback.await('mechanic:server:getVehicleFluidData', false, plate)
+end
+
+function State.applyInitialData(vehicle, data)
+    if not data or not DoesEntityExist(vehicle) then return end
+
+    local state = Entity(vehicle).state
+    state:set('oilLevel', data.oilLevel or 100, true)
+    state:set('coolantLevel', data.coolantLevel or 100, true)
+    state:set('brakeFluidLevel', data.brakeFluidLevel or 100, true)
+    state:set('transmissionFluidLevel', data.transmissionFluidLevel or 100, true)
+    state:set('powerSteeringLevel', data.powerSteeringLevel or 100, true)
+    state:set('tireWear', data.tireWear or 0, true)
+    state:set('batteryLevel', data.batteryLevel or 100, true)
+    state:set('gearBoxHealth', data.gearBoxHealth or 100, true)
+end
+
+local function collectFluidData(vehicle)
+    local state = Entity(vehicle).state
+
+    return {
+        oilLevel = state.oilLevel or 100,
+        coolantLevel = state.coolantLevel or 100,
+        brakeFluidLevel = state.brakeFluidLevel or 100,
+        transmissionFluidLevel = state.transmissionFluidLevel or 100,
+        powerSteeringLevel = state.powerSteeringLevel or 100
+    }
+end
+
+function State.pushToServer(vehicle)
+    if not DoesEntityExist(vehicle) then return end
+
+    local plate = GetVehicleNumberPlateText(vehicle)
+    if not plate or plate == '' then return end
+
+    TriggerServerEvent('mechanic:server:syncFluidLevels', plate, collectFluidData(vehicle))
+end
+
+function State.cleanupHandlingCache(cache)
+    local cleaned = 0
+
+    for vehicle in pairs(cache) do
+        if not DoesEntityExist(vehicle) then
+            cache[vehicle] = nil
+            cleaned = cleaned + 1
+        end
+    end
+
+    if cleaned > 0 then
+        print(string.format('[FluidEffects] Cleaned %d stale vehicle entries', cleaned))
+    end
+end
+
+return State

--- a/client/modules/fluid_effects.lua
+++ b/client/modules/fluid_effects.lua
@@ -1,573 +1,156 @@
 local FluidEffects = {}
 
-local effectsThread = nil
-local originalHandling = {}
+local Effects = require 'client.modules.fluid.effects'
+local Degradation = require 'client.modules.fluid.degradation'
+local State = require 'client.modules.fluid.state'
 
-function FluidEffects.Start()
-    if effectsThread then return end
-    
-    -- Cargar datos iniciales del servidor
-    local plate = GetVehicleNumberPlateText(cache.vehicle)
-    lib.callback('mechanic:server:getVehicleFluidData', false, function(data)
-        if data and cache.vehicle then
-            local vehicleState = Entity(cache.vehicle).state
-            vehicleState:set('oilLevel', data.oilLevel, true)
-            vehicleState:set('coolantLevel', data.coolantLevel, true)
-            vehicleState:set('brakeFluidLevel', data.brakeFluidLevel, true)
-            vehicleState:set('transmissionFluidLevel', data.transmissionFluidLevel, true)
-            vehicleState:set('powerSteeringLevel', data.powerSteeringLevel, true)
-            vehicleState:set('tireWear', data.tireWear or 0, true)
-            vehicleState:set('batteryLevel', data.batteryLevel or 100, true)
-            vehicleState:set('gearBoxHealth', data.gearBoxHealth or 100, true)
-        end
-    end, plate)
-    
-    effectsThread = CreateThread(function()
-        local lastDegradation = 0
-        local lastSync = 0
-        local lastMileage = 0
-        
+local handlingCache = {}
+local effectsThreadActive = false
+local trackedVehicle = nil
+local cleanupThreadStarted = false
+local collisionWatcherStarted = false
+
+local function startCleanupThread()
+    if cleanupThreadStarted then return end
+    cleanupThreadStarted = true
+
+    CreateThread(function()
         while true do
-            local vehicle = cache.vehicle
-            
-            if vehicle and cache.seat == -1 then
-                local vehicleState = Entity(vehicle).state
+            Wait(600000)
+            State.cleanupHandlingCache(handlingCache)
+        end
+    end)
+end
+
+local function startCollisionWatcher()
+    if collisionWatcherStarted then return end
+    collisionWatcherStarted = true
+
+    CreateThread(function()
+        local lastBodyHealth = {}
+
+        while true do
+            if effectsThreadActive and trackedVehicle and DoesEntityExist(trackedVehicle) then
+                local vehicle = trackedVehicle
+                local plate = GetVehicleNumberPlateText(vehicle) or 'unknown'
+                local currentBodyHealth = GetVehicleBodyHealth(vehicle)
+                local previousBodyHealth = lastBodyHealth[plate]
+
+                if previousBodyHealth then
+                    local damage = previousBodyHealth - currentBodyHealth
+                    if damage > 20 then
+                        Degradation.onCollision(vehicle, damage)
+                    end
+                end
+
+                lastBodyHealth[plate] = currentBodyHealth
+            else
+                lastBodyHealth = {}
+            end
+
+            Wait(500)
+        end
+    end)
+end
+
+local function startEffectsThread(vehicle)
+    if effectsThreadActive and trackedVehicle == vehicle then return end
+
+    if effectsThreadActive then
+        FluidEffects.Stop()
+    end
+
+    if not DoesEntityExist(vehicle) then return end
+
+    trackedVehicle = vehicle
+
+    local plate = GetVehicleNumberPlateText(vehicle)
+    local initialData = State.fetchInitialData(plate)
+    State.applyInitialData(vehicle, initialData)
+
+    effectsThreadActive = true
+
+    CreateThread(function()
+        local lastDegradation = GetGameTimer()
+        local lastSync = GetGameTimer()
+        local lastMileage = 0.0
+
+        while effectsThreadActive and trackedVehicle == vehicle do
+            local waitMs = 1000
+
+            if cache.vehicle == vehicle and cache.seat == -1 and DoesEntityExist(vehicle) then
+                local state = Entity(vehicle).state
+
+                Effects.applyBrake(vehicle, state.brakeFluidLevel or 100, handlingCache)
+                Effects.applyEngine(vehicle, state.oilLevel or 100, state.coolantLevel or 100)
+                Effects.applySteering(vehicle, state.powerSteeringLevel or 100, handlingCache)
+                Effects.applyTireWear(vehicle, state.tireWear or 0, handlingCache)
+                Effects.applyBattery(vehicle, state.batteryLevel or 100)
+                Effects.applyGearbox(vehicle, state.gearBoxHealth or 100)
+
+                local coords = GetEntityCoords(vehicle)
+                local mileage = coords.x + coords.y
                 local currentTime = GetGameTimer()
-                
-                -- Get fluid and component levels
-                local brakeFluid = vehicleState.brakeFluidLevel or 100
-                local oilLevel = vehicleState.oilLevel or 100
-                local coolantLevel = vehicleState.coolantLevel or 100
-                local powerSteeringFluid = vehicleState.powerSteeringLevel or 100
-                local tireWear = vehicleState.tireWear or 0
-                local batteryLevel = vehicleState.batteryLevel or 100
-                local gearBoxHealth = vehicleState.gearBoxHealth or 100
-                local mileage = GetEntityCoords(vehicle).x + GetEntityCoords(vehicle).y -- Just as an example
-                
-                -- Apply effects
-                FluidEffects.ApplyBrakeEffect(vehicle, brakeFluid)
-                FluidEffects.ApplyEngineEffect(vehicle, oilLevel, coolantLevel)
-                FluidEffects.ApplySteeringEffect(vehicle, powerSteeringFluid)
-                FluidEffects.ApplyTireWearEffect(vehicle, tireWear)
-                FluidEffects.ApplyBatteryEffect(vehicle, batteryLevel)
-                FluidEffects.ApplyGearBoxEffect(vehicle, gearBoxHealth)
-                
-                -- Degradación automática cada 30 segundos y por kilometraje
+
                 if currentTime - lastDegradation >= 30000 or math.abs(mileage - lastMileage) >= 1 then
-                    FluidEffects.DegradeFluidLevels(vehicle)
-                    FluidEffects.DegradeComponents(vehicle)
+                    Degradation.applyFluidLoss(vehicle)
+                    Degradation.applyComponentWear(vehicle)
                     lastDegradation = currentTime
                     lastMileage = mileage
                 end
 
-                -- Sincronización con servidor cada 5 minutos
                 if currentTime - lastSync >= 300000 then
- 300000 then
-                    FluidEffects.SyncWithServer(vehicle)
+                    State.pushToServer(vehicle)
                     lastSync = currentTime
                 end
+            else
+                waitMs = 1500
             end
-            
-            Wait(1000)
+
+            Wait(waitMs)
         end
     end)
 end
 
+function FluidEffects.Start(vehicle)
+    if not vehicle or cache.seat ~= -1 then return end
+
+    startCleanupThread()
+    startCollisionWatcher()
+    startEffectsThread(vehicle)
+end
+
 function FluidEffects.Stop()
-    if effectsThread then
-        effectsThread = nil
-    end
-    
-    -- Limpiar memoria de handling guardado
-    for vehicle, _ in pairs(originalHandling) do
-        if not DoesEntityExist(vehicle) then
-            originalHandling[vehicle] = nil
-        end
-    end
-    
-    -- Sincronizar datos finales con el servidor si había un vehículo
-    if cache.vehicle then
-        local plate = GetVehicleNumberPlateText(cache.vehicle)
-        local vehicleState = Entity(cache.vehicle).state
-        local fluidData = {
-            oilLevel = vehicleState.oilLevel or 100,
-            coolantLevel = vehicleState.coolantLevel or 100,
-            brakeFluidLevel = vehicleState.brakeFluidLevel or 100,
-            transmissionFluidLevel = vehicleState.transmissionFluidLevel or 100,
-            powerSteeringLevel = vehicleState.powerSteeringLevel or 100
-        }
-        TriggerServerEvent('mechanic:server:syncFluidLevels', plate, fluidData)
-    end
-end
+    if not effectsThreadActive then return end
 
-function FluidEffects.ApplyBrakeEffect(vehicle, fluidLevel)
-    if not originalHandling[vehicle] then
-        originalHandling[vehicle] = {
-            brakeForce = GetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce')
-        }
-    end
-    
-    if fluidLevel < 30 then
-        -- Frenos muy débiles
-        local reducedBrakeForce = originalHandling[vehicle].brakeForce * 0.3
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', reducedBrakeForce)
-        
-        -- Show warning once
-        if not Entity(vehicle).state.lowBrakeWarning then
-            Entity(vehicle).state:set('lowBrakeWarning', true, true)
-            lib.notify({
-                title = locale('low_brake_fluid'),
-                description = locale('brakes_severely_reduced'),
-                type = 'error',
-                duration = 8000
-            })
-        end
-    elseif fluidLevel < 50 then
-        -- Frenos reducidos
-        local reducedBrakeForce = originalHandling[vehicle].brakeForce * 0.6
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', reducedBrakeForce)
-        
-        if not Entity(vehicle).state.lowBrakeWarning then
-            Entity(vehicle).state:set('lowBrakeWarning', true, true)
-            lib.notify({
-                title = locale('low_brake_fluid'),
-                description = locale('brakes_reduced'),
-                type = 'warning',
-                duration = 6000
-            })
-        end
-    else
-        -- Restaurar frenos normales
-        if originalHandling[vehicle] then
-            SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fBrakeForce', originalHandling[vehicle].brakeForce)
-            Entity(vehicle).state:set('lowBrakeWarning', false, true)
-        end
-    end
-end
+    effectsThreadActive = false
 
-function FluidEffects.ApplyEngineEffect(vehicle, oilLevel, coolantLevel)
-    local engineTemp = Entity(vehicle).state.engineTemp or 90
-    
-    -- Efecto del aceite bajo
-    if oilLevel < 30 then
-        -- Aumentar desgaste del motor
-        local currentHealth = GetVehicleEngineHealth(vehicle)
-        SetVehicleEngineHealth(vehicle, currentHealth - 0.5)
-        
-        -- Reducir potencia
-        ModifyVehicleTopSpeed(vehicle, 0.7)
-        
-        if not Entity(vehicle).state.lowOilWarning then
-            Entity(vehicle).state:set('lowOilWarning', true, true)
-            lib.notify({
-                title = locale('low_engine_oil'),
-                description = locale('engine_damage_risk'),
-                type = 'error',
-                duration = 8000
-            })
-        end
-    else
-        ModifyVehicleTopSpeed(vehicle, 1.0)
-        Entity(vehicle).state:set('lowOilWarning', false, true)
-    end
-    
-    -- Efecto del refrigerante bajo
-    if coolantLevel < 30 then
-        -- Aumentar temperatura del motor rápidamente
-        engineTemp = math.min(engineTemp + 2.0, 150)
-        Entity(vehicle).state:set('engineTemp', engineTemp, true)
-        
-        if engineTemp > 120 then
-            -- Motor sobrecalentado
-            SetVehicleEngineOn(vehicle, false, true, false)
-            
-            lib.notify({
-                title = locale('engine_overheated'),
-                description = locale('engine_shutdown'),
-                type = 'error',
-                duration = 10000
-            })
-            
-            -- Humo del motor
-            SetVehicleEngineHealth(vehicle, -100.0)
-        elseif not Entity(vehicle).state.lowCoolantWarning then
-            Entity(vehicle).state:set('lowCoolantWarning', true, true)
-            lib.notify({
-                title = locale('low_coolant'),
-                description = locale('engine_overheating'),
-                type = 'warning',
-                duration = 8000
-            })
-        end
-    else
-        -- Enfriar el motor gradualmente
-        if engineTemp > 90 then
-            engineTemp = math.max(engineTemp - 0.5, 90)
-            Entity(vehicle).state:set('engineTemp', engineTemp, true)
-        end
-        Entity(vehicle).state:set('lowCoolantWarning', false, true)
-    end
-end
+    local vehicle = trackedVehicle
+    trackedVehicle = nil
 
-function FluidEffects.ApplySteeringEffect(vehicle, fluidLevel)
-    if fluidLevel < 30 then
-        -- Dirección muy pesada
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', 25.0)
-        
-        if not Entity(vehicle).state.lowSteeringWarning then
-            Entity(vehicle).state:set('lowSteeringWarning', true, true)
-            lib.notify({
-                title = locale('low_power_steering'),
-                description = locale('steering_difficulty'),
-                type = 'warning',
-                duration = 6000
-            })
-        end
-    elseif fluidLevel < 50 then
-        -- Dirección ligeramente pesada
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', 35.0)
-        
-        if not Entity(vehicle).state.lowSteeringWarning then
-            Entity(vehicle).state:set('lowSteeringWarning', true, true)
-            lib.notify({
-                title = locale('low_power_steering'),
-                description = locale('steering_slightly_heavy'),
-                type = 'info',
-                duration = 5000
-            })
-        end
-    else
-        -- Restaurar dirección normal
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fSteeringLock', 40.0)
-        Entity(vehicle).state:set('lowSteeringWarning', false, true)
-    end
-end
-
-function FluidEffects.ApplyTireWearEffect(vehicle, tireWear)
-    if tireWear > 80 then
-        -- Ruedas muy desgastadas - riesgo de explosión
-        if math.random(1, 1000) <= 5 then -- 0.5% de probabilidad
-            local tireIndex = math.random(0, 3)
-            SetVehicleTyreBurst(vehicle, tireIndex, false, 1000.0)
-            
-            lib.notify({
-                title = locale('tire_blowout'),
-                description = locale('tire_worn_out'),
-                type = 'error',
-                duration = 8000
-            })
-        end
-        
-        -- Reducir tracción
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', 0.7)
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', 0.5)
-        
-        if not Entity(vehicle).state.tireWearWarning then
-            Entity(vehicle).state:set('tireWearWarning', true, true)
-            lib.notify({
-                title = locale('tire_wear_critical'),
-                description = locale('replace_tires_soon'),
-                type = 'error',
-                duration = 10000
-            })
-        end
-    elseif tireWear > 60 then
-        -- Ruedas desgastadas - tracción reducida
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', 0.85)
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', 0.75)
-        
-        if not Entity(vehicle).state.tireWearWarning then
-            Entity(vehicle).state:set('tireWearWarning', true, true)
-            lib.notify({
-                title = locale('tire_wear_high'),
-                description = locale('consider_tire_replacement'),
-                type = 'warning',
-                duration = 8000
-            })
-        end
-    else
-        -- Ruedas en buen estado
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMax', 1.0)
-        SetVehicleHandlingFloat(vehicle, 'CHandlingData', 'fTractionCurveMin', 1.0)
-        Entity(vehicle).state:set('tireWearWarning', false, true)
-    end
-end
-
-function FluidEffects.ApplyBatteryEffect(vehicle, batteryLevel)
-    if batteryLevel < 20 then
-        -- Batería muy baja - riesgo de apagado
-        if math.random(1, 100) <= 10 then -- 10% de probabilidad cada segundo
-            SetVehicleEngineOn(vehicle, false, true, false)
-            
-            lib.notify({
-                title = locale('battery_dead'),
-                description = locale('vehicle_wont_start'),
-                type = 'error',
-                duration = 10000
-            })
-        end
-        
-        -- Luces más débiles
-        SetVehicleLightMultiplier(vehicle, 0.3)
-        
-        if not Entity(vehicle).state.batteryWarning then
-            Entity(vehicle).state:set('batteryWarning', true, true)
-            lib.notify({
-                title = locale('battery_critical'),
-                description = locale('charge_battery_soon'),
-                type = 'error',
-                duration = 8000
-            })
-        end
-    elseif batteryLevel < 40 then
-        -- Batería baja - luces débiles
-        SetVehicleLightMultiplier(vehicle, 0.7)
-        
-        if not Entity(vehicle).state.batteryWarning then
-            Entity(vehicle).state:set('batteryWarning', true, true)
-            lib.notify({
-                title = locale('battery_low'),
-                description = locale('battery_needs_attention'),
-                type = 'warning',
-                duration = 6000
-            })
-        end
-    else
-        -- Batería en buen estado
-        SetVehicleLightMultiplier(vehicle, 1.0)
-        Entity(vehicle).state:set('batteryWarning', false, true)
-    end
-end
-
-function FluidEffects.ApplyGearBoxEffect(vehicle, gearBoxHealth)
-    if gearBoxHealth < 30 then
-        -- Caja de cambios muy dañada
-        if math.random(1, 100) <= 5 then -- 5% de probabilidad
-            -- Cambio aleatorio de marcha
-            local randomGear = math.random(-1, 6)
-            SetVehicleGear(vehicle, randomGear)
-            
-            lib.notify({
-                title = locale('gearbox_failure'),
-                description = locale('gears_changing_randomly'),
-                type = 'error',
-                duration = 8000
-            })
-        end
-        
-        if not Entity(vehicle).state.gearBoxWarning then
-            Entity(vehicle).state:set('gearBoxWarning', true, true)
-            lib.notify({
-                title = locale('gearbox_critical'),
-                description = locale('transmission_failing'),
-                type = 'error',
-                duration = 10000
-            })
-        end
-    elseif gearBoxHealth < 60 then
-        -- Caja de cambios dañada - cambios lentos
-        if math.random(1, 200) <= 1 then -- Menor probabilidad de fallo
-            SetVehicleGear(vehicle, GetVehicleCurrentGear(vehicle)) -- Mantener marcha actual
-        end
-        
-        if not Entity(vehicle).state.gearBoxWarning then
-            Entity(vehicle).state:set('gearBoxWarning', true, true)
-            lib.notify({
-                title = locale('gearbox_worn'),
-                description = locale('gear_changes_slow'),
-                type = 'warning',
-                duration = 6000
-            })
-        end
-    else
-        -- Caja de cambios en buen estado
-        Entity(vehicle).state:set('gearBoxWarning', false, true)
-    end
-end
-
-function FluidEffects.DegradeComponents(vehicle)
-    local vehicleState = Entity(vehicle).state
-    local speed = GetEntitySpeed(vehicle) * 3.6
-    local engineHealth = GetVehicleEngineHealth(vehicle)
-    local bodyHealth = GetVehicleBodyHealth(vehicle)
-    
-    -- Desgaste de neumáticos basado en velocidad y superficie
-    local tireWearRate = 0.01 -- Base rate
-    if speed > 80 then
-        tireWearRate = tireWearRate * 2
-    end
-    if speed > 150 then
-        tireWearRate = tireWearRate * 3
-    end
-    
-    -- Superficie del terreno
-    local surfaceHash = GetVehicleWheelSurfaceMaterial(vehicle, 0)
-    if surfaceHash == GetHashKey('SAND') or surfaceHash == GetHashKey('ROCK') then
-        tireWearRate = tireWearRate * 1.5
-    end
-    
-    local currentTireWear = vehicleState.tireWear or 0
-    vehicleState:set('tireWear', math.min(100, currentTireWear + tireWearRate), true)
-    
-    -- Desgaste de batería
-    local batteryDrainRate = 0.02
-    if engineHealth < 800 then
-        batteryDrainRate = batteryDrainRate * 2
-    end
-    if speed == 0 and GetIsVehicleEngineRunning(vehicle) then
-        batteryDrainRate = batteryDrainRate * 1.5 -- Ralentí consume batería
-    end
-    
-    local currentBattery = vehicleState.batteryLevel or 100
-    vehicleState:set('batteryLevel', math.max(0, currentBattery - batteryDrainRate), true)
-    
-    -- Desgaste de caja de cambios
-    local gearBoxDamageRate = 0.01
-    if speed > 120 then
-        gearBoxDamageRate = gearBoxDamageRate * 2
-    end
-    if bodyHealth < 800 then
-        gearBoxDamageRate = gearBoxDamageRate * 1.5
-    end
-    
-    local currentGearBox = vehicleState.gearBoxHealth or 100
-    vehicleState:set('gearBoxHealth', math.max(0, currentGearBox - gearBoxDamageRate), true)
-end
-
--- Función para detectar colisiones
-function FluidEffects.OnVehicleCollision(vehicle, damage)
-    local vehicleState = Entity(vehicle).state
-    
-    -- Daño a la batería por impacto
-    local batteryDamage = damage * 0.1
-    local currentBattery = vehicleState.batteryLevel or 100
-    vehicleState:set('batteryLevel', math.max(0, currentBattery - batteryDamage), true)
-    
-    -- Daño a la caja de cambios
-    local gearBoxDamage = damage * 0.15
-    local currentGearBox = vehicleState.gearBoxHealth or 100
-    vehicleState:set('gearBoxHealth', math.max(0, currentGearBox - gearBoxDamage), true)
-    
-    -- Daño a los neumáticos
-    if damage > 50 then
-        local tireDamage = damage * 0.2
-        local currentTireWear = vehicleState.tireWear or 0
-        vehicleState:set('tireWear', math.min(100, currentTireWear + tireDamage), true)
-    end
-end
-
-function FluidEffects.DegradeFluidLevels(vehicle)
-    local vehicleState = Entity(vehicle).state
-    local engineHealth = GetVehicleEngineHealth(vehicle)
-    local speed = GetEntitySpeed(vehicle) * 3.6 -- Convertir a km/h
-    
-    -- Degradación base
-    local oilDegradation = 0.1
-    local coolantDegradation = 0.1
-    local brakeDegradation = 0.05
-    local steeringDegradation = 0.05
-    
-    -- Aumentar degradación si el motor está dañado
-    if engineHealth < 900 then
-        oilDegradation = oilDegradation * 2
-        coolantDegradation = coolantDegradation * 1.5
-    end
-    
-    -- Aumentar degradación por alta velocidad
-    if speed > 120 then
-        oilDegradation = oilDegradation * 1.5
-        coolantDegradation = coolantDegradation * 2
-        brakeDegradation = brakeDegradation * 2
-    end
-    
-    -- Aplicar degradación
-    local currentOil = vehicleState.oilLevel or 100
-    local currentCoolant = vehicleState.coolantLevel or 100
-    local currentBrake = vehicleState.brakeFluidLevel or 100
-    local currentSteering = vehicleState.powerSteeringLevel or 100
-    
-    vehicleState:set('oilLevel', math.max(0, currentOil - oilDegradation), true)
-    vehicleState:set('coolantLevel', math.max(0, currentCoolant - coolantDegradation), true)
-    vehicleState:set('brakeFluidLevel', math.max(0, currentBrake - brakeDegradation), true)
-    vehicleState:set('powerSteeringLevel', math.max(0, currentSteering - steeringDegradation), true)
-end
-
-function FluidEffects.SyncWithServer(vehicle)
-    local plate = GetVehicleNumberPlateText(vehicle)
-    local vehicleState = Entity(vehicle).state
-    
-    local fluidData = {
-        oilLevel = vehicleState.oilLevel or 100,
-        coolantLevel = vehicleState.coolantLevel or 100,
-        brakeFluidLevel = vehicleState.brakeFluidLevel or 100,
-        transmissionFluidLevel = vehicleState.transmissionFluidLevel or 100,
-        powerSteeringLevel = vehicleState.powerSteeringLevel or 100
-    }
-    
-    TriggerServerEvent('mechanic:server:syncFluidLevels', plate, fluidData)
-end
-
-function FluidEffects.CleanupMemory()
-    -- Limpiar vehículos que ya no existen
-    local cleaned = 0
-    for vehicle, _ in pairs(originalHandling) do
-        if not DoesEntityExist(vehicle) then
-            originalHandling[vehicle] = nil
-            cleaned = cleaned + 1
-        end
-    end
-    if cleaned > 0 then
-        print(string.format('[FluidEffects] Cleaned %d stale vehicle entries', cleaned))
+    if vehicle and DoesEntityExist(vehicle) then
+        State.pushToServer(vehicle)
+        Effects.restoreHandling(vehicle, handlingCache)
     end
 end
 
 function FluidEffects.Monitor()
+    startCleanupThread()
+    startCollisionWatcher()
+
     lib.onCache('vehicle', function(vehicle)
-        if vehicle then
-            FluidEffects.Start()
+        if vehicle and cache.seat == -1 then
+            FluidEffects.Start(vehicle)
         else
             FluidEffects.Stop()
-            originalHandling = {}
         end
     end)
-    
+
     lib.onCache('seat', function(seat)
-        if cache.vehicle and seat == -1 then
-            FluidEffects.Start()
-        elseif seat ~= -1 then
+        if seat == -1 and cache.vehicle then
+            FluidEffects.Start(cache.vehicle)
+        else
             FluidEffects.Stop()
-        end
-    end)
-    
-    -- Thread de limpieza de memoria cada 10 minutos
-    CreateThread(function()
-        while true do
-            Wait(600000) -- 10 minutos
-            FluidEffects.CleanupMemory()
-        end
-    end)
-    
-    -- Thread de detección de colisiones
-    CreateThread(function()
-        local lastBodyHealth = {}
-        
-        while true do
-            if cache.vehicle and cache.seat == -1 then
-                local vehicle = cache.vehicle
-                local currentBodyHealth = GetVehicleBodyHealth(vehicle)
-                local plate = GetVehicleNumberPlateText(vehicle)
-                
-                if lastBodyHealth[plate] then
-                    local damage = lastBodyHealth[plate] - currentBodyHealth
-                    if damage > 20 then -- Colisión significativa
-                        FluidEffects.OnVehicleCollision(vehicle, damage)
-                    end
-                end
-                
-                lastBodyHealth[plate] = currentBodyHealth
-            end
-            
-            Wait(500) -- Check every 0.5 seconds
         end
     end)
 end

--- a/fluid_effects_flow_analysis.md
+++ b/fluid_effects_flow_analysis.md
@@ -3,189 +3,50 @@
 ## Checklist de Verificación ✓
 
 ### 1. Inicialización del Sistema
-- [ ] **Client Init (client/init.lua)**
-  - Línea 17: `FluidEffects = require 'client.modules.fluid_effects'` - Carga del módulo
-  - Línea 33: `FluidEffects.Monitor()` - Inicia monitoreo al cargar jugador
-  - Línea 49: `FluidEffects.Monitor()` - Inicia monitoreo si recurso reinicia
+- [x] **Client Init (`client/init.lua`)**
+  - `local FluidEffects = require 'client.modules.fluid_effects'` - Carga el orquestador.
+  - `FluidEffects.Monitor()` - Activa el monitoreo cuando el jugador se conecta o al reiniciar el recurso.
 
-### 2. Sistema de Monitoreo (client/modules/fluid_effects.lua)
-- [ ] **Monitor Function (línea 182-199)**
-  - `lib.onCache('vehicle')` - Detecta entrada/salida de vehículo
-  - `lib.onCache('seat')` - Detecta cambio de asiento
-  - Solo activa efectos si jugador es conductor (seat == -1)
+### 2. Arquitectura Modular (client/modules/fluid)
+- [x] **`fluid/effects.lua`**
+  - Agrupa la lógica de aplicación de efectos (frenos, motor, dirección, neumáticos, batería, caja de cambios).
+  - Usa `Entity(vehicle).state` para debouncing de notificaciones con ox_lib.
+- [x] **`fluid/degradation.lua`**
+  - Encapsula desgaste periódico, degradación de fluidos y respuesta a colisiones.
+- [x] **`fluid/state.lua`**
+  - Sincroniza datos con el servidor mediante `lib.callback.await` y `TriggerServerEvent`.
 
-### 3. Thread Principal de Efectos (líneas 9-30)
-- [ ] **Condiciones de Ejecución**
-  - Verifica cada 1000ms (1 segundo)
-  - Solo ejecuta si: `vehicle` existe Y `cache.seat == -1`
-  - Obtiene niveles de fluidos del estado del vehículo
+### 3. Sistema de Monitoreo (`client/modules/fluid_effects.lua`)
+- [x] `lib.onCache('vehicle')` y `lib.onCache('seat')` detectan cambios de vehículo y asiento.
+- [x] `startCleanupThread()` realiza limpieza cada 10 minutos utilizando el estado compartido.
+- [x] `startCollisionWatcher()` aisla la detección de impactos para aplicar desgaste adicional solo cuando hay un vehículo monitoreado.
 
-### 4. Obtención de Datos de Fluidos
-- [ ] **Server Side (server/modules/vehicles.lua)**
-  - Línea 25-42: `GetFluidData()` - Obtiene datos de DB o valores default
-  - Línea 246-248: Callback registrado para obtener datos
-  - Línea 250-252: Callback para actualizar datos
+### 4. Thread Principal de Efectos
+- [x] Se crea con `CreateThread` únicamente cuando el jugador es conductor.
+- [x] Intervalo base de 1000 ms; se extiende a 1500 ms cuando el jugador no cumple condiciones para reducir uso de CPU.
+- [x] Usa datos en caché (`Entity(vehicle).state`) para evitar accesos redundantes.
+- [x] Sincroniza con el servidor cada 5 minutos y degrada fluidos/componentes cada 30 segundos o al recorrer 1 unidad de millaje virtual.
 
-### 5. Aplicación de Efectos
+### 5. Obtención de Datos de Fluidos
+- [x] `State.fetchInitialData()` llama a `mechanic:server:getVehicleFluidData` utilizando `ox_lib`.
+- [x] `State.applyInitialData()` prepara el estado local antes de iniciar efectos.
+- [x] `State.pushToServer()` envía actualizaciones con `mechanic:server:syncFluidLevels`.
 
-#### A. Efectos de Frenos (líneas 39-82)
-- [ ] **Niveles Críticos (<30%)**
-  - Reduce fuerza de frenado a 30% del original
-  - Muestra notificación de error (líneas 54-59)
-  - Guarda estado de advertencia para evitar spam
-  
-- [ ] **Niveles Bajos (<50%)**
-  - Reduce fuerza de frenado a 60% del original
-  - Muestra notificación de advertencia (líneas 68-73)
-  
-- [ ] **Niveles Normales (≥50%)**
-  - Restaura fuerza de frenado original
-  - Limpia estado de advertencia
+### 6. Aplicación de Efectos (Resumen)
+- **Frenos:** Ajusta `fBrakeForce` según nivel y muestra notificaciones escalonadas.
+- **Motor:** Gestiona daños por aceite bajo, sobrecalentamiento y restablece temperatura progresivamente.
+- **Dirección:** Cambia `fSteeringLock` para simular dirección pesada.
+- **Neumáticos:** Controla probabilidad de reventón y tracción (`fTractionCurveMax/Min`).
+- **Batería:** Atenúa luces y apaga motor cuando el nivel es crítico.
+- **Caja de Cambios:** Simula cambios aleatorios o lentitud según salud de transmisión.
 
-#### B. Efectos de Motor (líneas 84-146)
-- [ ] **Aceite Bajo (<30%)**
-  - Daña motor continuamente (-0.5 salud/segundo)
-  - Reduce velocidad máxima a 70%
-  - Notificación de error (líneas 98-103)
-  
-- [ ] **Refrigerante Bajo (<30%)**
-  - Aumenta temperatura +2°C/segundo
-  - Si temperatura > 120°C: Apaga motor automáticamente
-  - Activa humo del motor (línea 128)
-  - Notificaciones según severidad
+### 7. Estrategias de Rendimiento
+- Uso de caché de handling (`handlingCache`) para restaurar valores originales al salir del vehículo.
+- Limpieza periódica mediante `State.cleanupHandlingCache()` para evitar fugas de memoria.
+- Separación de responsabilidades en módulos dedicados para facilitar pruebas unitarias y mantenibilidad.
 
-#### C. Efectos de Dirección (líneas 148-180)
-- [ ] **Fluido Crítico (<30%)**
-  - Reduce ángulo de giro a 25° (muy pesado)
-  - Notificación de advertencia
-  
-- [ ] **Fluido Bajo (<50%)**
-  - Reduce ángulo de giro a 35° (ligeramente pesado)
-  - Notificación informativa
-
-### 6. Posibles Errores y Soluciones
-
-#### Error 1: Datos de Fluidos No Sincronizados
-```lua
--- Problema: vehicleState.brakeFluidLevel puede ser nil
--- Solución actual: Línea 17-20 usa "or 100" como fallback
-local brakeFluid = vehicleState.brakeFluidLevel or 100
-```
-
-#### Error 2: Memory Leak con originalHandling
-```lua
--- Problema: originalHandling nunca se limpia para vehículos anteriores
--- Solución necesaria: Limpiar tabla cuando jugador sale del vehículo
-function FluidEffects.Stop()
-    if effectsThread then
-        effectsThread = nil
-    end
-    -- Agregar limpieza de memoria
-    for vehicle, _ in pairs(originalHandling) do
-        if not DoesEntityExist(vehicle) then
-            originalHandling[vehicle] = nil
-        end
-    end
-end
-```
-
-#### Error 3: Múltiples Notificaciones
-```lua
--- Problema: Las notificaciones pueden aparecer cada segundo
--- Solución actual: Se usa Entity.state para trackear advertencias mostradas
--- Líneas 52, 67, 97, 130, 154, 167
-```
-
-#### Error 4: Sincronización Cliente-Servidor
-```lua
--- Problema: Los datos de fluidos pueden no estar actualizados
--- Necesario: Implementar sincronización periódica
--- Actualmente depende de callbacks manuales
-```
-
-### 7. Flujo Completo desde Perspectiva del Jugador
-
-1. **Jugador entra al servidor**
-   - QBCore:Client:OnPlayerLoaded dispara
-   - FluidEffects.Monitor() inicia
-   
-2. **Jugador entra a un vehículo como conductor**
-   - lib.onCache('vehicle') detecta cambio
-   - lib.onCache('seat') verifica que es conductor
-   - FluidEffects.Start() inicia thread
-   
-3. **Cada segundo mientras conduce**
-   - Thread verifica niveles de fluidos
-   - Aplica efectos según niveles:
-     - Frenos: Modifica fBrakeForce
-     - Motor: Modifica salud y velocidad
-     - Dirección: Modifica fSteeringLock
-   
-4. **Jugador recibe feedback**
-   - Notificaciones visuales con ox_lib
-   - Cambios físicos en manejo del vehículo
-   - Efectos visuales (humo si motor sobrecalentado)
-   
-5. **Jugador sale del vehículo**
-   - lib.onCache detecta cambio
-   - FluidEffects.Stop() detiene thread
-   - originalHandling debería limpiarse (bug potencial)
-
-### 8. Integración con Sistema de Mantenimiento
-
-- [ ] Los mecánicos pueden rellenar fluidos usando items de Config.MaintenanceItems
-- [ ] Los datos se guardan en DB mediante Vehicles.UpdateFluidData()
-- [ ] La UI de diagnóstico muestra niveles actuales (diagnostic.lua)
-- [ ] Los fluidos se degradan con el tiempo (no implementado aún)
-
-### 9. Validaciones de Seguridad
-
-- [ ] ✓ Verifica que jugador sea conductor
-- [ ] ✓ Verifica que vehículo exista
-- [ ] ✓ Usa valores default si datos no existen
-- [ ] ✗ No valida permisos para modificar handling (potencial exploit)
-- [ ] ✗ No limpia memoria de vehículos antiguos
-
-### 10. Mejoras Recomendadas
-
-1. **Agregar degradación automática de fluidos**
-```lua
--- En el thread principal
-if GetVehicleEngineHealth(vehicle) < 1000 then
-    -- Reducir aceite más rápido si motor dañado
-    local currentOil = vehicleState.oilLevel or 100
-    Entity(vehicle).state:set('oilLevel', math.max(0, currentOil - 0.1), true)
-end
-```
-
-2. **Sincronización periódica con servidor**
-```lua
--- Cada 5 minutos, sincronizar con DB
-CreateThread(function()
-    while true do
-        Wait(300000) -- 5 minutos
-        if cache.vehicle then
-            local plate = GetVehicleNumberPlateText(cache.vehicle)
-            lib.callback('mechanic:server:syncFluidData', false, function(data)
-                -- Actualizar estado local
-            end, plate)
-        end
-    end
-end)
-```
-
-3. **Limpieza de memoria**
-```lua
--- Agregar en FluidEffects.Stop()
-originalHandling = {}
-```
-
-## Conclusión
-
-El sistema funciona correctamente en su flujo principal pero tiene algunas áreas de mejora:
-- Memory leaks potenciales con originalHandling
-- Falta degradación automática de fluidos
-- Necesita mejor sincronización cliente-servidor
-- Podría beneficiarse de validaciones adicionales de seguridad
-
-El jugador experimenta los efectos correctamente según los niveles de fluidos, con feedback visual y físico apropiado.
+### 8. Flujo Completo desde Perspectiva del Jugador
+1. **Jugador entra al servidor:** `FluidEffects.Monitor()` queda escuchando cambios de cache.
+2. **Jugador se sube como conductor:** `FluidEffects.Start(vehicle)` inicializa datos y lanza el thread principal.
+3. **Conducción:** Cada ciclo aplica efectos, degrada componentes y sincroniza con el servidor según corresponda.
+4. **Jugador deja de conducir:** `FluidEffects.Stop()` detiene el thread, restaura handling y sincroniza los niveles finales.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -15,6 +15,7 @@ shared_scripts {
 
 client_scripts {
     'client/modules/*.lua',
+    'client/modules/fluid/*.lua',
     'client/modules/tuning.lua',
     'client/modules/billing.lua',
     'client/init.lua'


### PR DESCRIPTION
## Summary
- split the fluid simulation into dedicated effects, degradation, and state modules that leverage ox_lib state handling
- refactor the fluid effects controller to start and stop threads using cache events while adding cleanup and collision monitoring
- document the new layout, register the modules in fxmanifest, and record the changes in the changelog

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ff9f2bfa58832cabb9810052ccd45b