### PR TITLE
Fix server vehicle property sync relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Updated the fluid effects controller to use cache-driven start/stop logic and reduce idle processing while the player is not driving.
 ### Fixed
 - Restored the billing menu part selector by sourcing maintenance and part pricing from configuration data, allowing invoices to include all service items without errors.
+- Renamed the server-side vehicle property sync event to `mechanic:server:syncVehicleProperties` so it no longer intercepts the client handler and continues forwarding updates with `TriggerClientEvent`.

--- a/server/modules/vehicles.lua
+++ b/server/modules/vehicles.lua
@@ -274,11 +274,8 @@ RegisterNetEvent('mechanic:server:repairVehiclePart', function(plate, part, amou
 end)
 
 -- Sync vehicle properties to clients
-RegisterNetEvent('mechanic:client:syncVehicleProperties', function(netId, props)
-    local vehicle = NetworkGetEntityFromNetworkId(netId)
-    if DoesEntityExist(vehicle) then
-        exports.ox_lib:setVehicleProperties(vehicle, props)
-    end
+RegisterNetEvent('mechanic:server:syncVehicleProperties', function(netId, props)
+    TriggerClientEvent('mechanic:client:syncVehicleProperties', -1, netId, props)
 end)
 
 -- Sincronización de niveles de fluidos


### PR DESCRIPTION
## Summary
- rename the server vehicle property sync event to `mechanic:server:syncVehicleProperties`
- keep forwarding updates through `TriggerClientEvent` to the existing client handler
- document the event change in the changelog

## Testing
- not run (in-game testing requires FiveM client/server which is unavailable in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913668c9598832c82d6ddde5adc0bc7)